### PR TITLE
Fix setup bug: hntool script not found

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,10 +4,13 @@ from setuptools import setup
 from os.path import join
 from sys import prefix
 from HnTool import __version__
+from shutil import copyfile
 
 DATAFILES = [
       (join(prefix, 'share', 'man', 'man1'), [join('doc', 'hntool.1')]),
       ('share/doc/hntool-%s' % __version__, ['AUTHORS', 'LICENSE', 'NEWS', 'README', 'TODO'])]
+
+copyfile('hntool.py', 'hntool')
 
 setup(name='HnTool',
       version=str(__version__),


### PR DESCRIPTION
I always got this error when running setup.py on multiple distros (kali, ubuntu, CentOS):

dogoncouch@aviary:~/tmp/HnTool$ sudo python setup.py install --prefix /usr/ --root /
running install
running build
running build_py
creating build
creating build/lib
creating build/lib/HnTool
copying HnTool/__init__.py -> build/lib/HnTool
copying HnTool/core.py -> build/lib/HnTool
creating build/lib/HnTool/output
copying HnTool/output/terminal.py -> build/lib/HnTool/output
copying HnTool/output/__init__.py -> build/lib/HnTool/output
copying HnTool/output/html.py -> build/lib/HnTool/output
creating build/lib/HnTool/modules
copying HnTool/modules/filesystems.py -> build/lib/HnTool/modules
copying HnTool/modules/ssh.py -> build/lib/HnTool/modules
copying HnTool/modules/proftpd.py -> build/lib/HnTool/modules
copying HnTool/modules/__init__.py -> build/lib/HnTool/modules
copying HnTool/modules/php.py -> build/lib/HnTool/modules
copying HnTool/modules/authentication.py -> build/lib/HnTool/modules
copying HnTool/modules/remote.py -> build/lib/HnTool/modules
copying HnTool/modules/postgresql.py -> build/lib/HnTool/modules
copying HnTool/modules/vsftpd.py -> build/lib/HnTool/modules
copying HnTool/modules/selinux.py -> build/lib/HnTool/modules
copying HnTool/modules/ports.py -> build/lib/HnTool/modules
copying HnTool/modules/util.py -> build/lib/HnTool/modules
copying HnTool/modules/rule.py -> build/lib/HnTool/modules
copying HnTool/modules/system-wide.py -> build/lib/HnTool/modules
copying HnTool/modules/apache.py -> build/lib/HnTool/modules
running build_scripts
creating build/scripts-2.6
error: file '/home/dogoncouch/tmp/HnTool/hntool' does not exist

The fix was either to copy the file during setup.py or move the file from hntool.py to hntool. Let me know if you think moving the script to hntool would be a better idea.